### PR TITLE
Hover widget: Markdown renderer - combine MarkdownRendererOptions wit…

### DIFF
--- a/src/vs/editor/browser/core/markdownRenderer.ts
+++ b/src/vs/editor/browser/core/markdownRenderer.ts
@@ -7,8 +7,7 @@ import { IMarkdownString } from 'vs/base/common/htmlContent';
 import {
 	renderMarkdown,
 	MarkdownRenderOptions,
-	MarkedOptions,
-	SanitizerConfig
+	MarkedOptions
 } from 'vs/base/browser/markdownRenderer';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -56,7 +55,7 @@ export class MarkdownRenderer {
 		this._onDidRenderAsync.dispose();
 	}
 
-	render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, markedOptions?: MarkedOptions, sanitizerConfig?: SanitizerConfig): IMarkdownRenderResult {
+	render(markdown: IMarkdownString | undefined, options?: MarkdownRenderOptions, markedOptions?: MarkedOptions): IMarkdownRenderResult {
 		if (!markdown) {
 			const element = document.createElement('span');
 			return { element, dispose: () => { } };
@@ -66,8 +65,7 @@ export class MarkdownRenderer {
 		const rendered = disposables.add(renderMarkdown(
 			markdown,
 			{ ...this._getRenderOptions(markdown, disposables), ...options },
-			markedOptions,
-			sanitizerConfig
+			markedOptions
 		));
 		return {
 			element: rendered.element,

--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -6,7 +6,7 @@
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
-import { SanitizerConfig } from 'vs/base/browser/markdownRenderer';
+import { MarkdownRenderOptions } from 'vs/base/browser/markdownRenderer';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, registerEditorAction, registerEditorContribution, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
@@ -228,8 +228,8 @@ export class ModesHoverController implements IEditorContribution {
 		this._contentWidget?.dispose();
 	}
 
-	public setMarkdownSanitizerConfig(config: SanitizerConfig) {
-		this._getOrCreateContentWidget().setMarkdownSanitizerConfig(config);
+	public setMarkdownRendererOptions(options: MarkdownRenderOptions) {
+		this._getOrCreateContentWidget().setMarkdownRendererOptions(options);
 	}
 }
 

--- a/src/vs/editor/contrib/hover/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/markdownHoverParticipant.ts
@@ -8,7 +8,7 @@ import { asArray } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IMarkdownString, isEmptyMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
-import { SanitizerConfig } from 'vs/base/browser/markdownRenderer';
+import { MarkdownRenderOptions } from 'vs/base/browser/markdownRenderer';
 import { MarkdownRenderer } from 'vs/editor/browser/core/markdownRenderer';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Position } from 'vs/editor/common/core/position';
@@ -42,7 +42,7 @@ export class MarkdownHover implements IHoverPart {
 }
 
 export class MarkdownHoverParticipant implements IEditorHoverParticipant<MarkdownHover> {
-	private _markdownSanitizerConfig?: SanitizerConfig;
+	private _markdownRendererOptions?: MarkdownRenderOptions;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -116,8 +116,8 @@ export class MarkdownHoverParticipant implements IEditorHoverParticipant<Markdow
 		return result;
 	}
 
-	public setMarkdownSanitizerConfig(config: SanitizerConfig) {
-		this._markdownSanitizerConfig = config;
+	public setMarkdownRendererOptions(options: MarkdownRenderOptions) {
+		this._markdownRendererOptions = options;
 	}
 
 	public renderHoverParts(hoverParts: MarkdownHover[], fragment: DocumentFragment, statusBar: IEditorHoverStatusBar): IDisposable {
@@ -134,12 +134,7 @@ export class MarkdownHoverParticipant implements IEditorHoverParticipant<Markdow
 					hoverContentsElement.className = 'hover-contents code-hover-contents';
 					this._hover.onContentsChanged();
 				}));
-				const renderedContents = disposables.add(renderer.render(
-					contents,
-					undefined,
-					undefined,
-					this._markdownSanitizerConfig
-				));
+				const renderedContents = disposables.add(renderer.render(contents, this._markdownRendererOptions));
 				hoverContentsElement.appendChild(renderedContents.element);
 				fragment.appendChild(markdownHoverElement);
 			}

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -7,7 +7,7 @@ import * as dom from 'vs/base/browser/dom';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { HoverAction, HoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
 import { Widget } from 'vs/base/browser/ui/widget';
-import { SanitizerConfig } from 'vs/base/browser/markdownRenderer';
+import { MarkdownRenderOptions } from 'vs/base/browser/markdownRenderer';
 import { coalesce, flatten } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -503,8 +503,8 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 		this._onDidContentsChanged.fire();
 	}
 
-	public setMarkdownSanitizerConfig(config: SanitizerConfig) {
-		this._markdownHoverParticipant.setMarkdownSanitizerConfig(config);
+	public setMarkdownRendererOptions(options: MarkdownRenderOptions) {
+		this._markdownHoverParticipant.setMarkdownRendererOptions(options);
 	}
 
 	private _withResult(result: IHoverPart[], complete: boolean): void {


### PR DESCRIPTION
Расширил `MarkdownRendererOptions` следующими полями:
* `headingBlockRenderer` - для возможности переопределить, как будет рисоваться тег `h[1-6]`. Будет использоваться для "дорисовки" к имени функции, к которой выведен тултип, кнопки открытия справки
* `onClickHandler?: (content: string, event?: IMouseEvent) => boolean` - для обработки нажатия на вышеуказанную кнопку, при возвращении `false`, будет выполняться логика стандартного обработчика
* `sanitizerConfig`

`SanitizerConfig` и `MarkdownRendererOptions` для предотвращения дублирования кода. Если бы оба объекта передавались отдельными методами, то во всех затронутых ревизией файлах было бы дублирование методов `setMarkdownSanitizerConfig/setMarkdownRendererOptions`

https://user-images.githubusercontent.com/3891063/137945652-ad4067db-7c45-49dd-9b86-d3493d7d0348.mp4



