### PR TITLE
Suggest widget: Completion items - support completion items custom kinds

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -512,7 +512,7 @@ export interface CompletionItem {
 	 * The kind of this completion item. Based on the kind
 	 * an icon is chosen by the editor.
 	 */
-	kind: CompletionItemKind;
+	kind: CompletionItemKind | number;
 	/**
 	 * A modifier to the `kind` which affect how the item
 	 * is rendered, e.g. Deprecated is rendered with a strikeout

--- a/src/vs/editor/contrib/suggest/suggestWidgetRenderer.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidgetRenderer.ts
@@ -197,7 +197,10 @@ export class ItemRenderer implements IListRenderer<CompletionItem, ISuggestionTe
 			// normal icon
 			data.icon.className = 'icon hide';
 			data.iconContainer.className = '';
-			data.iconContainer.classList.add('suggest-icon', ...completionKindToCssClass(completion.kind).split(' '));
+			const className = this._themeService
+				.getExtendedCompletionItemKindTheme()
+				?.getIconClassName(completion.kind) || completionKindToCssClass(completion.kind);
+			data.iconContainer.classList.add('suggest-icon', ...className.split(' '));
 		}
 
 		if (completion.tags && completion.tags.indexOf(CompletionItemTag.Deprecated) >= 0) {

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -312,6 +312,13 @@ export function defineTheme(themeName: string, themeData: IStandaloneThemeData):
 }
 
 /**
+ * Define a new completion item kinds.
+ */
+export function defineExtendedCompletionItemKinds(completionItemKinds: Map<number, string>): void {
+	StaticServices.standaloneThemeService.get().registerExtendedCompletionItemKinds(completionItemKinds);
+}
+
+/**
  * Switches to a theme.
  */
 export function setTheme(themeName: string): void {
@@ -361,6 +368,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		colorizeModelLine: <any>colorizeModelLine,
 		tokenize: <any>tokenize,
 		defineTheme: <any>defineTheme,
+		defineExtendedCompletionItemKinds: <any>defineExtendedCompletionItemKinds,
 		setTheme: <any>setTheme,
 		remeasureFonts: remeasureFonts,
 		registerCommand: registerCommand,

--- a/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
@@ -13,7 +13,14 @@ import { hc_black, vs, vs_dark } from 'vs/editor/standalone/common/themes';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ColorIdentifier, Extensions, IColorRegistry } from 'vs/platform/theme/common/colorRegistry';
-import { Extensions as ThemingExtensions, ICssStyleCollector, IFileIconTheme, IThemingRegistry, ITokenStyle } from 'vs/platform/theme/common/themeService';
+import {
+	IExtendedCompletionItemKindTheme,
+	Extensions as ThemingExtensions,
+	ICssStyleCollector,
+	IFileIconTheme,
+	IThemingRegistry,
+	ITokenStyle
+} from 'vs/platform/theme/common/themeService';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
 import { getIconsStyleSheet } from 'vs/platform/theme/browser/iconsStyleSheet';
@@ -162,6 +169,23 @@ class StandaloneTheme implements IStandaloneTheme {
 	public readonly semanticHighlighting = false;
 }
 
+class ExtendedCompletionItemKindTheme implements IExtendedCompletionItemKindTheme {
+	private icons = new Map<number, string>();
+
+	getIconClassName(completionItemKind: number): string | undefined {
+		return this.icons.get(completionItemKind);
+	}
+
+	registerExtendedCompletionItemKind(items: Map<number, string>) {
+		items.forEach((className, kind) => {
+			if (kind <= 27) {
+				throw new Error(`CompletionItemKind error: cannot assign new icon for CompletionItemKind(${kind})`);
+			}
+			this.icons.set(kind, className);
+		});
+	}
+}
+
 function isBuiltinTheme(themeName: string): themeName is BuiltinTheme {
 	return (
 		themeName === VS_THEME_NAME
@@ -207,6 +231,7 @@ export class StandaloneThemeServiceImpl extends Disposable implements IStandalon
 	private _colorMapOverride: Color[] | null;
 	private _desiredTheme!: IStandaloneTheme;
 	private _theme!: IStandaloneTheme;
+	private _extendedCompletionItemKindTheme: ExtendedCompletionItemKindTheme;
 
 	constructor() {
 		super();
@@ -227,6 +252,7 @@ export class StandaloneThemeServiceImpl extends Disposable implements IStandalon
 		this._styleElements = [];
 		this._colorMapOverride = null;
 		this.setTheme(VS_THEME_NAME);
+		this._extendedCompletionItemKindTheme = new ExtendedCompletionItemKindTheme();
 
 		iconsStyleSheet.onDidChange(() => {
 			this._codiconCSS = iconsStyleSheet.getCSS();
@@ -236,6 +262,14 @@ export class StandaloneThemeServiceImpl extends Disposable implements IStandalon
 		dom.addMatchMediaChangeListener('(forced-colors: active)', () => {
 			this._updateActualTheme();
 		});
+	}
+
+	getExtendedCompletionItemKindTheme(): IExtendedCompletionItemKindTheme | undefined {
+        return this._extendedCompletionItemKindTheme;
+    }
+
+	registerExtendedCompletionItemKinds(items: Map<number, string>) {
+		this._extendedCompletionItemKindTheme.registerExtendedCompletionItemKind(items);
 	}
 
 	public registerEditorContainer(domNode: HTMLElement): IDisposable {

--- a/src/vs/editor/standalone/common/standaloneThemeService.ts
+++ b/src/vs/editor/standalone/common/standaloneThemeService.ts
@@ -39,4 +39,5 @@ export interface IStandaloneThemeService extends IThemeService {
 
 	setColorMapOverride(colorMapOverride: Color[] | null): void;
 
+	registerExtendedCompletionItemKinds(items: Map<number, string>): void;
 }

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -13,7 +13,12 @@ import { ILineTokens, IToken, TokenizationSupport2Adapter, TokensProvider } from
 import { IStandaloneTheme, IStandaloneThemeData, IStandaloneThemeService } from 'vs/editor/standalone/common/standaloneThemeService';
 import { ColorIdentifier } from 'vs/platform/theme/common/colorRegistry';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
-import { IFileIconTheme, IColorTheme, ITokenStyle } from 'vs/platform/theme/common/themeService';
+import {
+	IFileIconTheme,
+	IColorTheme,
+	ITokenStyle,
+	IExtendedCompletionItemKindTheme
+} from 'vs/platform/theme/common/themeService';
 
 suite('TokenizationSupport2Adapter', () => {
 
@@ -82,6 +87,13 @@ suite('TokenizationSupport2Adapter', () => {
 		}
 		public readonly onDidColorThemeChange = new Emitter<IColorTheme>().event;
 		public readonly onDidFileIconThemeChange = new Emitter<IFileIconTheme>().event;
+
+		getExtendedCompletionItemKindTheme(): IExtendedCompletionItemKindTheme | undefined {
+			return undefined;
+		}
+
+		registerExtendedCompletionItemKinds(items: Map<number, string>){
+		}
 	}
 
 	class MockState implements IState {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -973,6 +973,11 @@ declare namespace monaco.editor {
 	export function defineTheme(themeName: string, themeData: IStandaloneThemeData): void;
 
 	/**
+	 * Define a new completion item kinds.
+	 */
+	export function defineExtendedCompletionItemKinds(completionItemKinds: Map<number, string>): void;
+
+	/**
 	 * Switches to a theme.
 	 */
 	export function setTheme(themeName: string): void;
@@ -5836,7 +5841,7 @@ declare namespace monaco.languages {
 		 * The kind of this completion item. Based on the kind
 		 * an icon is chosen by the editor.
 		 */
-		kind: CompletionItemKind;
+		kind: CompletionItemKind | number;
 		/**
 		 * A modifier to the `kind` which affect how the item
 		 * is rendered, e.g. Deprecated is rendered with a strikeout

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -94,6 +94,10 @@ export interface ITokenStyle {
 	readonly italic?: boolean;
 }
 
+export interface IExtendedCompletionItemKindTheme {
+	getIconClassName(completionItemKind: number): string | undefined;
+}
+
 export interface IColorTheme {
 
 	readonly type: ColorScheme;
@@ -155,6 +159,7 @@ export interface IThemeService {
 
 	readonly onDidFileIconThemeChange: Event<IFileIconTheme>;
 
+	getExtendedCompletionItemKindTheme(): IExtendedCompletionItemKindTheme | undefined;
 }
 
 // static theming participant

--- a/src/vs/platform/theme/test/common/testThemeService.ts
+++ b/src/vs/platform/theme/test/common/testThemeService.ts
@@ -6,7 +6,13 @@
 import { Color } from 'vs/base/common/color';
 import { Emitter, Event } from 'vs/base/common/event';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
-import { IColorTheme, IFileIconTheme, IThemeService, ITokenStyle } from 'vs/platform/theme/common/themeService';
+import {
+	IExtendedCompletionItemKindTheme,
+	IColorTheme,
+	IFileIconTheme,
+	IThemeService,
+	ITokenStyle
+} from 'vs/platform/theme/common/themeService';
 
 export class TestColorTheme implements IColorTheme {
 
@@ -81,5 +87,9 @@ export class TestThemeService implements IThemeService {
 
 	public get onDidFileIconThemeChange(): Event<IFileIconTheme> {
 		return this._onFileIconThemeChange.event;
+	}
+
+	getExtendedCompletionItemKindTheme(): IExtendedCompletionItemKindTheme | undefined {
+		return undefined;
 	}
 }

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -13,7 +13,12 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import * as errors from 'vs/base/common/errors';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 import { ColorThemeData } from 'vs/workbench/services/themes/common/colorThemeData';
-import { IColorTheme, Extensions as ThemingExtensions, IThemingRegistry } from 'vs/platform/theme/common/themeService';
+import {
+	IColorTheme,
+	Extensions as ThemingExtensions,
+	IThemingRegistry,
+	IExtendedCompletionItemKindTheme
+} from 'vs/platform/theme/common/themeService';
 import { Event, Emitter } from 'vs/base/common/event';
 import { registerFileIconThemeSchemas } from 'vs/workbench/services/themes/common/fileIconThemeSchema';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -688,6 +693,10 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 		if (!silent) {
 			this.onProductIconThemeChange.fire(this.currentProductIconTheme);
 		}
+	}
+
+	getExtendedCompletionItemKindTheme(): IExtendedCompletionItemKindTheme | undefined {
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
Добавил поддержку иконок для пользовательских значений для поля `CompletionItem::kind`.
Регистрация пользовательских типов происходит через метод
`function defineExtendedCompletionItemKinds(completionItemKinds: Map<number, string>)`

где `completionItemKinds` набор пар `пользовательский тип - иконка`
![image](https://user-images.githubusercontent.com/3891063/138097402-e53d8a8e-95ed-4791-ae85-a9b66349a66d.png)
