### PR TITLE
More open monaco-editor api

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -45,7 +45,7 @@ declare namespace monaco {
 #include(vs/editor/common/standalone/standaloneBase): KeyMod
 #include(vs/base/common/htmlContent): IMarkdownString
 #include(vs/base/browser/keyboardEvent): IKeyboardEvent
-#include(vs/base/browser/mouseEvent): IMouseEvent
+#include(vs/base/browser/mouseEvent): IMouseEvent, IMouseWheelEvent
 #include(vs/editor/common/editorCommon): IScrollEvent
 #include(vs/editor/common/core/position): IPosition, Position
 #include(vs/editor/common/core/range): IRange, Range

--- a/build/monaco/monaco.usage.recipe
+++ b/build/monaco/monaco.usage.recipe
@@ -4,6 +4,8 @@
 import { ServiceIdentifier } from './vs/platform/instantiation/common/instantiation';
 import { create as create1 } from './vs/base/common/worker/simpleWorker';
 import { create as create2 } from './vs/editor/common/services/editorSimpleWorker';
+import { ModesHoverController } from './vs/editor/contrib/hover/hover';
+import { SuggestController } from './vs/editor/contrib/suggest/suggestController';
 import { SyncDescriptor0, SyncDescriptor1, SyncDescriptor2, SyncDescriptor3, SyncDescriptor4, SyncDescriptor5, SyncDescriptor6, SyncDescriptor7, SyncDescriptor8 } from './vs/platform/instantiation/common/descriptors';
 import * as editorAPI from './vs/editor/editor.api';
 
@@ -13,6 +15,12 @@ import * as editorAPI from './vs/editor/editor.api';
 	a = (<ServiceIdentifier<any>>b).type;
 	a = create1;
 	a = create2;
+
+	a = (<ModesHoverController>b).onDidContentsChanged
+	a = (<ModesHoverController>b).getLastHoveredRange
+	a = (<ModesHoverController>b).setMarkdownRendererOptions
+
+	a = (<SuggestController>b).onDidAcceptSelectedSuggestion
 
 	// injection madness
 	a = (<SyncDescriptor0<any>>b).ctor;

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -539,7 +539,6 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	/**
 	 * An event emitted on a "mousewheel"
 	 * @event
-	 * @internal
 	 */
 	onMouseWheel(listener: (e: IMouseWheelEvent) => void): IDisposable;
 	/**

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -1206,26 +1206,22 @@ export interface ITextModel {
 	/**
 	 * Undo edit operations until the previous undo/redo point.
 	 * The inverse edit operations will be pushed on the redo stack.
-	 * @internal
 	 */
 	undo(): void | Promise<void>;
 
 	/**
 	 * Is there anything in the undo stack?
-	 * @internal
 	 */
 	canUndo(): boolean;
 
 	/**
 	 * Redo edit operations until the next undo/redo point.
 	 * The inverse edit operations will be pushed on the undo stack.
-	 * @internal
 	 */
 	redo(): void | Promise<void>;
 
 	/**
 	 * Is there anything in the redo stack?
-	 * @internal
 	 */
 	canRedo(): boolean;
 
@@ -1271,7 +1267,6 @@ export interface ITextModel {
 	/**
 	 * An event emitted when the tokens associated with the model have changed.
 	 * @event
-	 * @internal
 	 */
 	onDidChangeTokens(listener: (e: IModelTokensChangedEvent) => void): IDisposable;
 	/**

--- a/src/vs/editor/common/model/textModelEvents.ts
+++ b/src/vs/editor/common/model/textModelEvents.ts
@@ -84,7 +84,6 @@ export interface IModelDecorationsChangedEvent {
 
 /**
  * An event describing that some ranges of lines have been tokenized (their tokens have changed).
- * @internal
  */
 export interface IModelTokensChangedEvent {
 	readonly tokenizationSupportChanged: boolean;

--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -231,6 +231,14 @@ export class ModesHoverController implements IEditorContribution {
 	public setMarkdownRendererOptions(options: MarkdownRenderOptions) {
 		this._getOrCreateContentWidget().setMarkdownRendererOptions(options);
 	}
+
+	public onDidContentsChanged(listener: (element: HTMLElement) => void) {
+		this._getOrCreateContentWidget().onDidContentsChanged(listener);
+	}
+
+	public getLastHoveredRange(): Range | undefined {
+		return this._getOrCreateContentWidget().getLastHoveredRange();
+	}
 }
 
 class ShowHoverAction extends EditorAction {
@@ -301,7 +309,6 @@ class ShowDefinitionPreviewHoverAction extends EditorAction {
 		const range = new Range(position.lineNumber, position.column, position.lineNumber, position.column);
 		const goto = GotoDefinitionAtPositionEditorContribution.get(editor);
 		const promise = goto.startFindDefinitionFromCursor(position);
-		controller.setMarkdownRendererOptions({});
 		promise.then(() => {
 			controller.showContentHover(range, HoverStartMode.Immediate, true);
 		});

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -203,8 +203,8 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 	private _renderDisposable: IDisposable | null;
 	private _markdownHoverParticipant: MarkdownHoverParticipant;
 
-	protected readonly _onDidContentsChanged: Emitter<void> = this._register(new Emitter<void>());
-	public readonly onDidContentsChanged: Event<void> = this._onDidContentsChanged.event;
+	protected readonly _onDidContentsChanged: Emitter<HTMLElement> = this._register(new Emitter<HTMLElement>());
+	public readonly onDidContentsChanged: Event<HTMLElement> = this._onDidContentsChanged.event;
 
 	constructor(
 		editor: ICodeEditor,
@@ -393,7 +393,7 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 
 		this._editor.layoutContentWidget(this);
 		this._hover.onContentsChanged();
-		this._onDidContentsChanged.fire();
+		this._onDidContentsChanged.fire(this.getDomNode());
 	}
 
 	private layout(): void {
@@ -500,11 +500,15 @@ export class ModesContentHoverWidget extends Widget implements IContentWidget, I
 
 	public onContentsChanged(): void {
 		this._hover.onContentsChanged();
-		this._onDidContentsChanged.fire();
+		this._onDidContentsChanged.fire(this.getDomNode());
 	}
 
 	public setMarkdownRendererOptions(options: MarkdownRenderOptions) {
 		this._markdownHoverParticipant.setMarkdownRendererOptions(options);
+	}
+
+	public getLastHoveredRange(): Range | undefined {
+		return this._lastAnchor?.range;
 	}
 
 	private _withResult(result: IHoverPart[], complete: boolean): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -448,6 +448,16 @@ declare namespace monaco {
 		stopPropagation(): void;
 	}
 
+	export interface IMouseWheelEvent extends MouseEvent {
+		readonly wheelDelta: number;
+		readonly wheelDeltaX: number;
+		readonly wheelDeltaY: number;
+		readonly deltaX: number;
+		readonly deltaY: number;
+		readonly deltaZ: number;
+		readonly deltaMode: number;
+	}
+
 	export interface IScrollEvent {
 		readonly scrollTop: number;
 		readonly scrollLeft: number;
@@ -2032,6 +2042,24 @@ declare namespace monaco.editor {
 		 */
 		setEOL(eol: EndOfLineSequence): void;
 		/**
+		 * Undo edit operations until the previous undo/redo point.
+		 * The inverse edit operations will be pushed on the redo stack.
+		 */
+		undo(): void | Promise<void>;
+		/**
+		 * Is there anything in the undo stack?
+		 */
+		canUndo(): boolean;
+		/**
+		 * Redo edit operations until the next undo/redo point.
+		 * The inverse edit operations will be pushed on the undo stack.
+		 */
+		redo(): void | Promise<void>;
+		/**
+		 * Is there anything in the redo stack?
+		 */
+		canRedo(): boolean;
+		/**
 		 * An event emitted when the contents of the model have changed.
 		 * @event
 		 */
@@ -2056,6 +2084,11 @@ declare namespace monaco.editor {
 		 * @event
 		 */
 		onDidChangeLanguageConfiguration(listener: (e: IModelLanguageConfigurationChangedEvent) => void): IDisposable;
+		/**
+		 * An event emitted when the tokens associated with the model have changed.
+		 * @event
+		 */
+		onDidChangeTokens(listener: (e: IModelTokensChangedEvent) => void): IDisposable;
 		/**
 		 * An event emitted when the model has been attached to the first editor or detached from the last editor.
 		 * @event
@@ -2571,6 +2604,24 @@ declare namespace monaco.editor {
 	export interface IModelDecorationsChangedEvent {
 		readonly affectsMinimap: boolean;
 		readonly affectsOverviewRuler: boolean;
+	}
+
+	/**
+	 * An event describing that some ranges of lines have been tokenized (their tokens have changed).
+	 */
+	export interface IModelTokensChangedEvent {
+		readonly tokenizationSupportChanged: boolean;
+		readonly semanticTokensApplied: boolean;
+		readonly ranges: {
+			/**
+			 * The start of the range (inclusive)
+			 */
+			readonly fromLineNumber: number;
+			/**
+			 * The end of the range (inclusive)
+			 */
+			readonly toLineNumber: number;
+		}[];
 	}
 
 	export interface IModelOptionsChangedEvent {
@@ -4870,6 +4921,11 @@ declare namespace monaco.editor {
 		 * @event
 		 */
 		onMouseLeave(listener: (e: IPartialEditorMouseEvent) => void): IDisposable;
+		/**
+		 * An event emitted on a "mousewheel"
+		 * @event
+		 */
+		onMouseWheel(listener: (e: IMouseWheelEvent) => void): IDisposable;
 		/**
 		 * An event emitted on a "keyup".
 		 * @event


### PR DESCRIPTION
Сделал более открытое api для взаимодействия с редактором.
`monaco.d.ts.recipe` - указываются типы, которые должны попасть в тайпинги
`monaco.usage.recipe` - спасает неиспользуемые методы/поля от tree shaking'a