### PR TITLE
Emit parsed token info for nested language

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -3382,6 +3382,10 @@ export class TextModel extends Disposable implements model.ITextModel, IDecorati
 		// Columns start with 1.
 		return indentOfLine(this.getLineContent(lineNumber)) + 1;
 	}
+
+	setTokenizationInfoEmitterLineIndex(index: number) {
+		this._tokenization.setTokenizationInfoEmitterLineIndex(index);
+	}
 }
 
 function indentOfLine(line: string): number {

--- a/src/vs/editor/common/model/textModelTokens.ts
+++ b/src/vs/editor/common/model/textModelTokens.ts
@@ -331,6 +331,10 @@ export class TextModelTokenization extends Disposable {
 		return false;
 	}
 
+	public setTokenizationInfoEmitterLineIndex(index: number) {
+		this._tokenizationSupport?.setLineIndex?.(index);
+	}
+
 	private _hasLinesToTokenize(): boolean {
 		if (!this._tokenizationSupport) {
 			return false;

--- a/src/vs/editor/standalone/common/monarch/monarchLexer.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchLexer.ts
@@ -237,6 +237,7 @@ interface IMonarchTokensCollector {
 export type TokensCollectorEmitListener = (line: number, offset: number, type: string) => void;
 export interface TokenInfoEmitter {
 	emit(offset: number, type: string): void;
+	getLineIndex(): number;
 }
 
 class MonarchClassicTokensCollector implements IMonarchTokensCollector {
@@ -315,6 +316,7 @@ class MonarchModernTokensCollector implements IMonarchTokensCollector {
 	}
 
 	public emit(startOffset: number, type: string): void {
+		this._emitter?.emit(startOffset, type);
 		let metadata = this._theme.match(this._currentLanguageId, type);
 		if (this._lastTokenMetadata === metadata) {
 			return;
@@ -322,7 +324,6 @@ class MonarchModernTokensCollector implements IMonarchTokensCollector {
 		this._lastTokenMetadata = metadata;
 		this._tokens.push(startOffset);
 		this._tokens.push(metadata);
-		this._emitter?.emit(startOffset, type);
 	}
 
 	private static _merge(a: Uint32Array | null, b: number[], c: Uint32Array | null): Uint32Array {
@@ -364,6 +365,7 @@ class MonarchModernTokensCollector implements IMonarchTokensCollector {
 			return embeddedModeState;
 		}
 
+		this._emitter && nestedModeTokenizationSupport.setLineIndex?.(this._emitter.getLineIndex());
 		let nestedResult = nestedModeTokenizationSupport.tokenize2(embeddedModeLine, hasEOL, embeddedModeState, offsetDelta);
 		this._prependTokens = MonarchModernTokensCollector._merge(this._prependTokens, this._tokens, nestedResult.tokens);
 		this._tokens = [];
@@ -395,6 +397,10 @@ class ParsedTokenInfoEmitter implements TokenInfoEmitter {
 		if (this.line >= 0) {
 			this.listener(this.line, offset, type);
 		}
+	}
+
+	getLineIndex(): number {
+		return this.line;
 	}
 }
 


### PR DESCRIPTION
Информация о токенах из embedded-токенизатора не попадала в `TokenStore`
