### PR TITLE
make suggest widget behavior similar to native client suggestion list…

### DIFF
--- a/src/vs/editor/contrib/suggest/suggest.ts
+++ b/src/vs/editor/contrib/suggest/suggest.ts
@@ -27,6 +27,7 @@ export const Context = {
 	Visible: new RawContextKey<boolean>('suggestWidgetVisible', false, localize('suggestWidgetVisible', "Whether suggestion are visible")),
 	DetailsVisible: new RawContextKey<boolean>('suggestWidgetDetailsVisible', false, localize('suggestWidgetDetailsVisible', "Whether suggestion details are visible")),
 	MultipleSuggestions: new RawContextKey<boolean>('suggestWidgetMultipleSuggestions', false, localize('suggestWidgetMultipleSuggestions', "Whether there are multiple suggestions to pick from")),
+	AtLeastOneSuggestion: new RawContextKey<boolean>('suggestWidgetAtLeastOneSuggestion', false, localize('suggestWidgetAtLeastOneSuggestion', "Whether there are at least one to pick from")),
 	MakesTextEdit: new RawContextKey('suggestionMakesTextEdit', true, localize('suggestionMakesTextEdit', "Whether inserting the current suggestion yields in a change or has everything already been typed")),
 	AcceptSuggestionsOnEnter: new RawContextKey<boolean>('acceptSuggestionOnEnter', true, localize('acceptSuggestionOnEnter', "Whether suggestions are inserted when pressing Enter")),
 	HasInsertAndReplaceRange: new RawContextKey('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behaviour")),

--- a/src/vs/editor/contrib/suggest/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/suggestController.ts
@@ -768,13 +768,13 @@ registerEditorCommand(new SuggestCommand({
 		weight: weight,
 		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyCode.Escape,
-		secondary: [KeyMod.Shift | KeyCode.Escape]
+		secondary: [KeyMod.Shift | KeyCode.Escape, KeyCode.RightArrow]
 	}
 }));
 
 registerEditorCommand(new SuggestCommand({
 	id: 'selectNextSuggestion',
-	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
+	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.AtLeastOneSuggestion),
 	handler: c => c.selectNextSuggestion(),
 	kbOpts: {
 		weight: weight,
@@ -799,13 +799,13 @@ registerEditorCommand(new SuggestCommand({
 
 registerEditorCommand(new SuggestCommand({
 	id: 'selectLastSuggestion',
-	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
+	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.AtLeastOneSuggestion),
 	handler: c => c.selectLastSuggestion()
 }));
 
 registerEditorCommand(new SuggestCommand({
 	id: 'selectPrevSuggestion',
-	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
+	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.AtLeastOneSuggestion),
 	handler: c => c.selectPrevSuggestion(),
 	kbOpts: {
 		weight: weight,
@@ -830,7 +830,7 @@ registerEditorCommand(new SuggestCommand({
 
 registerEditorCommand(new SuggestCommand({
 	id: 'selectFirstSuggestion',
-	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
+	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.AtLeastOneSuggestion),
 	handler: c => c.selectFirstSuggestion()
 }));
 


### PR DESCRIPTION
Переделал поведение виджета подсказок по аналогии с поведением списка вариантов в нативном редакторе, т.к. были жалобы, что слишком навязчиво.

При автоматическом показе виджета(т.е. по мере набора) выделение элемента из предложенного списка происходит лишь при совпадении уже введёного текста и начала предложенного от двух символов. При старом поведении сразу же выделялся первый элемент.

Виджет можно закрыть по нажатию на `Right Arrow`.

Для `SuggestModel` добавлен метод `showCompletionItems` для возможности показать готовый список вариантов, в обход провайдера `CompletionItemProvider`.
