### PR TITLE
Completion list item selector method - ability to set for each editor…

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -75,7 +75,7 @@ export interface ICommandHandler {
 #includeAll(vs/editor/common/model): IScrollEvent
 #include(vs/editor/common/diff/diffComputer): IChange, ICharChange, ILineChange
 #include(vs/editor/common/core/dimension): IDimension
-#includeAll(vs/editor/common/editorCommon): IScrollEvent
+#includeAll(vs/editor/common/editorCommon;CompletionItem=>languages.CompletionItem): IScrollEvent
 #includeAll(vs/editor/common/textModelEvents):
 #includeAll(vs/editor/common/cursorEvents):
 #include(vs/platform/accessibility/common/accessibility): AccessibilitySupport
@@ -95,7 +95,7 @@ declare namespace monaco.languages {
 #include(vs/editor/common/languageSelector): LanguageSelector, LanguageFilter
 #includeAll(vs/editor/standalone/browser/standaloneLanguages;languages.=>;editorCommon.=>editor.;model.=>editor.;IMarkerData=>editor.IMarkerData):
 #includeAll(vs/editor/common/languages/languageConfiguration):
-#includeAll(vs/editor/common/languages;IMarkerData=>editor.IMarkerData;ISingleEditOperation=>editor.ISingleEditOperation;model.=>editor.): Token
+#includeAll(vs/editor/common/languages;IMarkerData=>editor.IMarkerData;ISingleEditOperation=>editor.ISingleEditOperation;model.=>editor.;): Token
 #include(vs/editor/common/languages/language): ILanguageExtensionPoint
 #includeAll(vs/editor/standalone/common/monarch/monarchTypes):
 

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1003,6 +1003,16 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	hasModel(): this is IActiveCodeEditor;
 
 	setBanner(bannerDomNode: HTMLElement | null, height: number): void;
+
+	/**
+	 * Set a custom completion list item selection method.
+	 */
+	setCompletionListItemSelectorMethod(method: editorCommon.CompletionListItemSelectionMethod): void;
+
+	/**
+	 * Get a custom completion list item selection method.
+	 */
+	getCompletionListItemSelectorMethod(): editorCommon.CompletionListItemSelectionMethod | undefined;
 }
 
 /**

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -266,6 +266,8 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 	private _dropIntoEditorDecorationIds: string[] = [];
 
+	private completionListItemSelector?: editorCommon.CompletionListItemSelectionMethod;
+
 	constructor(
 		domElement: HTMLElement,
 		_options: Readonly<IEditorConstructionOptions>,
@@ -1830,6 +1832,14 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 	private removeDropIndicator(): void {
 		this._dropIntoEditorDecorationIds = this.deltaDecorations(this._dropIntoEditorDecorationIds, []);
+	}
+
+	public setCompletionListItemSelectorMethod(method: editorCommon.CompletionListItemSelectionMethod) {
+		this.completionListItemSelector = method;
+	}
+
+	public getCompletionListItemSelectorMethod(): editorCommon.CompletionListItemSelectionMethod | undefined {
+		return this.completionListItemSelector;
 	}
 }
 

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -11,6 +11,7 @@ import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
+import { CompletionItem } from 'vs/editor/common/languages';
 import { IModelDecorationsChangeAccessor, ITextModel, OverviewRulerLane, TrackedRangeStickiness, IValidEditOperation } from 'vs/editor/common/model';
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { IDimension } from 'vs/editor/common/core/dimension';
@@ -198,6 +199,11 @@ export const enum ScrollType {
 	Smooth = 0,
 	Immediate = 1,
 }
+
+export type CompletionItemInfo = { completion: CompletionItem; word?: string };
+
+export type CompletionListItemSelectionMethod
+	= (isAuto: boolean, selectionIndex: number, items: CompletionItemInfo[]) => number;
 
 /**
  * An editor.

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -693,11 +693,6 @@ export interface CompletionList {
 	duration?: number;
 }
 
-export type CompletionItemInfo = { completion: CompletionItem; word?: string };
-
-export type CompletionListItemSelectionMethod
-	= (isAuto: boolean, selectionIndex: number, items: CompletionItemInfo[]) => number;
-
 /**
  * How a suggest provider was triggered.
  */

--- a/src/vs/editor/common/services/editorCompletionService.ts
+++ b/src/vs/editor/common/services/editorCompletionService.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { FuzzyScorer } from 'vs/base/common/filters';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { CompletionListItemSelectionMethod } from 'vs/editor/common/languages';
 
 export const IEditorCompletionService = createDecorator<IEditorCompletionService>('completionScoreService');
 
@@ -13,15 +12,11 @@ export interface IEditorCompletionService {
 
 	registerCompletionScoreMethod(fuzzyScorer: FuzzyScorer): void;
 	getScorer(): FuzzyScorer | undefined;
-
-	registerCompletionListItemSelectorMethod(fuzzyScorer: CompletionListItemSelectionMethod): void;
-	getCompletionListItemSelectorMethod(): CompletionListItemSelectionMethod | undefined;
 }
 
 export class EditorCompletionServiceImpl implements IEditorCompletionService {
 	declare readonly _serviceBrand: undefined;
 	private scorer?: FuzzyScorer;
-	private completionListItemSelector?: CompletionListItemSelectionMethod;
 
 	registerCompletionScoreMethod(fuzzyScorer: FuzzyScorer): void {
 		this.scorer = fuzzyScorer;
@@ -29,12 +24,5 @@ export class EditorCompletionServiceImpl implements IEditorCompletionService {
 
 	getScorer(): FuzzyScorer | undefined {
 		return this.scorer;
-	}
-
-	registerCompletionListItemSelectorMethod(method: CompletionListItemSelectionMethod): void {
-		this.completionListItemSelector = method;
-	}
-	getCompletionListItemSelectorMethod(): CompletionListItemSelectionMethod | undefined {
-		return this.completionListItemSelector;
 	}
 }

--- a/src/vs/editor/contrib/suggest/browser/completionModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/completionModel.ts
@@ -8,7 +8,8 @@ import { CharCode } from 'vs/base/common/charCode';
 import { anyScore, fuzzyScore, FuzzyScore, fuzzyScoreGracefulAggressive, FuzzyScorer } from 'vs/base/common/filters';
 import { compareIgnoreCase } from 'vs/base/common/strings';
 import { InternalSuggestOptions } from 'vs/editor/common/config/editorOptions';
-import { CompletionItemKind, CompletionItemProvider, CompletionListItemSelectionMethod } from 'vs/editor/common/languages';
+import { CompletionListItemSelectionMethod } from 'vs/editor/common/editorCommon';
+import { CompletionItemKind, CompletionItemProvider } from 'vs/editor/common/languages';
 import { WordDistance } from 'vs/editor/contrib/suggest/browser/wordDistance';
 import { CompletionItem } from './suggest';
 

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -562,7 +562,7 @@ export class SuggestModel implements IDisposable {
 				this._editor.getOption(EditorOption.snippetSuggestions),
 				clipboardText,
 				this._editorCompletionScoreService.getScorer(),
-				this._editorCompletionScoreService.getCompletionListItemSelectorMethod()
+				this._editor.getCompletionListItemSelectorMethod()
 			);
 
 			// store containers so that they can be disposed later

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -22,7 +22,6 @@ import { IMonarchLanguage } from 'vs/editor/standalone/common/monarch/monarchTyp
 import { IStandaloneThemeService } from 'vs/editor/standalone/common/standaloneTheme';
 import { IMarkerData, IMarkerService } from 'vs/platform/markers/common/markers';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
-import { IEditorCompletionService } from 'vs/editor/common/services/editorCompletionService';
 import { LanguageSelector } from 'vs/editor/common/languageSelector';
 
 /**
@@ -657,13 +656,6 @@ export function registerInlayHintsProvider(languageSelector: LanguageSelector, p
 }
 
 /**
- * Register a custom completion list item selection method.
- */
-export function registerCompletionListItemSelectorMethod(method: languages.CompletionListItemSelectionMethod): void {
-	const editorCompletionService = StandaloneServices.get(IEditorCompletionService);
-	editorCompletionService.registerCompletionListItemSelectorMethod(method);
-}
-/**
  * Contains additional diagnostic information about the context in which
  * a [code action](#CodeActionProvider.provideCodeActions) is run.
  */
@@ -754,7 +746,6 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		registerDocumentRangeSemanticTokensProvider: <any>registerDocumentRangeSemanticTokensProvider,
 		registerInlineCompletionsProvider: <any>registerInlineCompletionsProvider,
 		registerInlayHintsProvider: <any>registerInlayHintsProvider,
-		registerCompletionListItemSelectorMethod: <any>registerCompletionListItemSelectorMethod,
 
 		// enums
 		DocumentHighlightKind: standaloneEnums.DocumentHighlightKind,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2358,6 +2358,13 @@ declare namespace monaco.editor {
 		Immediate = 1
 	}
 
+	export type CompletionItemInfo = {
+		completion: languages.CompletionItem;
+		word?: string;
+	};
+
+	export type CompletionListItemSelectionMethod = (isAuto: boolean, selectionIndex: number, items: CompletionItemInfo[]) => number;
+
 	/**
 	 * An editor.
 	 */
@@ -5407,6 +5414,14 @@ declare namespace monaco.editor {
 		 */
 		applyFontInfo(target: HTMLElement): void;
 		setBanner(bannerDomNode: HTMLElement | null, height: number): void;
+		/**
+		 * Set a custom completion list item selection method.
+		 */
+		setCompletionListItemSelectorMethod(method: CompletionListItemSelectionMethod): void;
+		/**
+		 * Get a custom completion list item selection method.
+		 */
+		getCompletionListItemSelectorMethod(): CompletionListItemSelectionMethod | undefined;
 	}
 
 	/**
@@ -5817,11 +5832,6 @@ declare namespace monaco.languages {
 	 * Register an inlay hints provider.
 	 */
 	export function registerInlayHintsProvider(languageSelector: LanguageSelector, provider: InlayHintsProvider): IDisposable;
-
-	/**
-	 * Register a custom completion list item selection method.
-	 */
-	export function registerCompletionListItemSelectorMethod(method: CompletionListItemSelectionMethod): void;
 
 	/**
 	 * Contains additional diagnostic information about the context in which
@@ -6288,13 +6298,6 @@ declare namespace monaco.languages {
 		incomplete?: boolean;
 		dispose?(): void;
 	}
-
-	export type CompletionItemInfo = {
-		completion: CompletionItem;
-		word?: string;
-	};
-
-	export type CompletionListItemSelectionMethod = (isAuto: boolean, selectionIndex: number, items: CompletionItemInfo[]) => number;
 
 	/**
 	 * How a suggest provider was triggered.


### PR DESCRIPTION
Возможность устанавливать значение `CompletionListItemSelectionMethod` для каждого инстанса редактора.
Реализация в предыдущих PR'ах позволяла установить такой метод лишь один на всех, что приводило к невозможности настроить разное поведение для разных инстансов редактора.

`CompletionListItemSelectionMethod` - метод для установки поведения редактора при показе списка автодополнения. Позволяет решить, выделять тот или иной элемент по мере ввода выражения, либо нет.